### PR TITLE
fix: run alembic migrations for both local postgres and Neon

### DIFF
--- a/chart/the-experiment/templates/backend-deployment.yaml
+++ b/chart/the-experiment/templates/backend-deployment.yaml
@@ -32,7 +32,6 @@ spec:
       serviceAccountName: {{ include "the-experiment.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.postgres.enabled }}
       initContainers:
         - name: migrate
           image: {{ include "the-experiment.backendImage" . }}
@@ -45,10 +44,11 @@ spec:
             - secretRef:
                 name: {{ include "the-experiment.neonSecretName" . }}
           {{- end }}
+          {{- if .Values.postgres.enabled }}
           env:
             - name: DATABASE_URL
               value: {{ include "the-experiment.postgresUrl" . | replace "+asyncpg" "+psycopg" | quote }}
-      {{- end }}
+          {{- end }}
       containers:
         - name: backend
           image: {{ include "the-experiment.backendImage" . }}


### PR DESCRIPTION
## Summary
- The migration init container in `backend-deployment.yaml` was gated behind `postgres.enabled`, so migrations **never ran in production** where Neon is used via `existingSecret`
- Additionally, the init container hardcoded the local postgres URL, ignoring the Neon secret's `DATABASE_URL`
- Moved the `postgres.enabled` gate to only wrap the explicit `DATABASE_URL` env override, so the init container always runs and gets its connection string from the right source (configmap for local, Neon K8s secret for production)

## Test plan
- [x] `make helm-lint` passes for default, production, and local values
- [x] `helm template` with production values shows init container loading `the-experiment-neon` secret
- [x] `helm template` with local values shows init container with explicit `+psycopg` DATABASE_URL override
- [ ] Deploy to local K8s and verify migrations run against in-cluster postgres
- [ ] Deploy to production and verify migrations run against Neon

🤖 Generated with [Claude Code](https://claude.com/claude-code)