### PR TITLE
fix: normalize DATABASE_URL driver for Neon

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -11,7 +11,20 @@ from app.db import models  # noqa: F401
 
 config = context.config
 settings = get_settings()
-config.set_main_option("sqlalchemy.url", settings.database_url.replace("+asyncpg", "+psycopg"))
+
+
+def _sync_url(url: str) -> str:
+    """Ensure the DATABASE_URL uses the psycopg (v3) sync driver for Alembic."""
+    if url.startswith("postgresql+psycopg://"):
+        return url
+    if url.startswith("postgresql+"):
+        return "postgresql+psycopg://" + url.split("://", 1)[1]
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+psycopg://", 1)
+    return url
+
+
+config.set_main_option("sqlalchemy.url", _sync_url(settings.database_url))
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -4,9 +4,22 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from app.core.config import get_settings
 
+
+def _async_url(url: str) -> str:
+    """Ensure the DATABASE_URL uses the asyncpg driver."""
+    if url.startswith("postgresql+asyncpg://"):
+        return url
+    if url.startswith("postgresql+"):
+        # Replace any other driver with asyncpg
+        return "postgresql+asyncpg://" + url.split("://", 1)[1]
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    return url
+
+
 settings = get_settings()
 
-engine = create_async_engine(settings.database_url, future=True)
+engine = create_async_engine(_async_url(settings.database_url), future=True)
 AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
 


### PR DESCRIPTION
## Summary
- Neon's `DATABASE_URL` uses bare `postgresql://` (no driver suffix), which SQLAlchemy defaults to **psycopg2** — not installed
- The alembic init container crashes on `ModuleNotFoundError: No module named 'psycopg2'`, preventing the backend pod from starting
- Helm `--wait --timeout 5m` then times out → every deploy since PR #27 has failed
- Fix: normalize the URL to `postgresql+asyncpg://` in `session.py` and `postgresql+psycopg://` in `alembic/env.py`

## Test plan
- [x] All 60 backend tests pass
- [x] URL normalization verified for bare, `+asyncpg`, and `+psycopg` inputs
- [ ] Deploy succeeds after merge (alembic init container starts, backend pod becomes ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)