### PR TITLE
Fix backend CORS defaults for production

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -16,6 +17,7 @@ class Settings(BaseSettings):
     log_level: str = "debug"
     database_url: str = "postgresql+asyncpg://experiment:experiment@localhost:5432/experiment"
     redis_url: str = "redis://localhost:6379/0"
+    platform_url: str | None = None
     cors_origins: list[str] = ["http://localhost:5173"]
     anthropic_api_key: str | None = None
     openai_api_key: str | None = None
@@ -28,6 +30,19 @@ class Settings(BaseSettings):
     llm_max_retries: int = 2
     llm_max_fallbacks: int = 2
     llm_default_temperature: float = 0.8
+
+    @field_validator("cors_origins", mode="before")
+    @classmethod
+    def _parse_cors_origins(cls, value: object) -> object:
+        if isinstance(value, str) and not value.startswith("["):
+            return [origin.strip() for origin in value.split(",") if origin.strip()]
+        return value
+
+    @model_validator(mode="after")
+    def _derive_cors_origins(self) -> "Settings":
+        if self.platform_url and self.cors_origins == ["http://localhost:5173"]:
+            self.cors_origins = [self.platform_url]
+        return self
 
 
 @lru_cache

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,22 @@
+from app.core.config import Settings
+
+
+def test_platform_url_overrides_localhost_cors_default() -> None:
+    settings = Settings(platform_url="https://the-experiment.gernerventures.com")
+
+    assert settings.cors_origins == ["https://the-experiment.gernerventures.com"]
+
+
+def test_explicit_cors_origins_take_precedence_over_platform_url() -> None:
+    settings = Settings(
+        platform_url="https://the-experiment.gernerventures.com",
+        cors_origins=["https://api.example.com"],
+    )
+
+    assert settings.cors_origins == ["https://api.example.com"]
+
+
+def test_cors_origins_accepts_comma_delimited_string() -> None:
+    settings = Settings(cors_origins="https://a.example.com, https://b.example.com")
+
+    assert settings.cors_origins == ["https://a.example.com", "https://b.example.com"]


### PR DESCRIPTION
## Summary
- derive backend CORS origins from `PLATFORM_URL` when the localhost default is still in effect
- preserve explicit `CORS_ORIGINS` values and support comma-delimited env input
- add focused settings tests for production and override behavior

## Problem
Production supplied `PLATFORM_URL`, but the backend never consumed it for CORS. Without an explicit `CORS_ORIGINS` env var, the app kept `allow_origins=["http://localhost:5173"]`, which is incorrect for production.

## Verification
- `poetry run pytest tests/test_config.py tests/test_api_layer.py`

## Notes
Doppler `the-experiment/prd` contains `DATABASE_URL` but does not contain `CORS_ORIGINS`, so the production path depended on this app-side wiring.