### PR TITLE
Add specwright specs for all open tickets

### DIFF
--- a/CANON.yaml
+++ b/CANON.yaml
@@ -1,0 +1,16 @@
+team: the-experiment
+ticket_systems:
+  primary:
+    system: github
+    project: Gerner-Ventures/the-experiment
+
+specs:
+  auto_tickets: false
+  require_review: false
+  doc_paths:
+    - "docs/specs/*.md"
+
+agents:
+  doc_updates: true
+  pr_analysis: true
+  stale_detection: 30d

--- a/docs/specs/S1.3-isometric-world.md
+++ b/docs/specs/S1.3-isometric-world.md
@@ -1,229 +1,38 @@
-# S1.3 — Isometric World with Map Themes and Agent Spawning
-
-## Status: DRAFT
-## Issue: #16
-
+---
+title: "S1.3 — Isometric World (PixiJS)"
+status: done
+issue: 16
+priority: done
+tags: [stream-1, frontend, pixi, isometric]
 ---
 
-## 1. Problem Statement
+# S1.3 — Isometric World (PixiJS)
 
-The experiment configuration screen is complete (PR #28). When the player clicks "Launch Experiment", nothing happens — `SimulationView.vue` is a placeholder. We need the isometric world renderer so agents can be placed on a themed map and the experiment feels alive.
+PixiJS v8 isometric world renderer with 4 themed environments, agent spawning, and camera controls.
 
-The original ticket scope was a generic isometric renderer. The updated scope adds **themed map environments** that change the visual identity of the world, and a **demo mode** where agents spawn on the map and perform random biological/silly actions using the existing pixel sprite animation system.
+## Completed (PR #33)
 
----
+- `IsometricMap.ts` — tile grid rendering with theme-specific ground textures
+- `BuildingRenderer.ts` — four unique architectural styles per theme
+- `TileRenderer.ts` — individual tile rendering with terrain types
+- `isometric-utils.ts` — coordinate math: `screenX = (tileX - tileY) * tileWidth/2`
+- `CameraController.ts` — pan (drag/WASD) and zoom (scroll/+/-)
+- `AmbientOverlay.ts` — theme effects (code rain, dust, smog, fog)
+- `usePixiWorld.ts` — Vue composable bridging reactivity to PixiJS
 
-## 2. Requirements
+## Acceptance Criteria
 
-### 2.1 Map Theme System
+- [x] 4 themed environments render correctly with distinct palettes
+- [x] Diamond projection isometric math with 64x32 tiles
+- [x] Buildings render with theme-specific architectural styles
+- [x] Camera pan (drag/WASD) and zoom (scroll) controls
+- [x] Ambient overlays per theme (code rain, dust, smog, fog)
+- [x] Map data loads from `default_town.json` (20x20, 400 tiles)
+- [x] Agents spawn at random walkable tiles
+- [x] Location labels on buildings
+- [x] 63 unit tests covering themes, math, spawning, map integrity
 
-The player selects a map theme during experiment configuration (new field alongside arc/parameters). Each theme defines:
-- **Tile palette** — colors for ground, paths, buildings, water, walls
-- **Building style** — pixel art building shapes rendered per-theme
-- **Ambient effects** — fog, rain, glow, scanlines, color grading
-- **Name and description** — shown in theme picker
+## Deferred to S1.9
 
-#### Themes
-
-| ID | Name | Ground | Buildings | Ambient | Inspiration |
-|---|---|---|---|---|---|
-| `lord-of-the-flies` | Castaway Island | Sand, jungle green, beach | Thatched huts, lean-tos, signal fire | Ocean shimmer, palm shadows | Tropical survival |
-| `matrix` | The Construct | Black, neon green grid | Wireframe cubes, data towers | Falling code rain, green scanlines | Matrix digital world |
-| `gladiator` | The Arena | Dusty sand, stone | Roman columns, colosseum arches, cells | Torch flicker, dust particles | Roman gladiatorial arena |
-| `1984` | Sector 7G | Dark concrete, rust | Brutalist towers, smokestacks, pipes | Smog overlay, dim orange glow, rain | 1984 × Blade Runner industrial |
-
-Each theme maps to the same 20×20 tile grid structure from the backend (`default_town.json`), but re-skins every tile type.
-
-### 2.2 Isometric Renderer (PixiJS)
-
-- **PixiJS v8 Application** embedded in a Vue component via `usePixiWorld()` composable
-- **Diamond-projection isometric tiles** — each tile is a diamond (64×32 base, configurable)
-- **Tile layers**: ground → path → building → decoration → agent
-- **Buildings** rendered as multi-tile isometric structures with height
-- **Location labels** shown on hover or toggle
-- **Camera**: pan (drag/arrow keys), zoom (scroll/+/-), center on agent (click dossier)
-
-### 2.3 Agent Spawning & Random Actions
-
-When the experiment launches (demo mode — no backend required yet):
-- All configured agents spawn at random walkable tiles
-- Each agent renders their pixel sprite (from `character-sprites.ts`) on the isometric grid
-- Agents randomly:
-  - Walk to adjacent walkable tiles (pathfinding not required yet, just random neighbor)
-  - Perform random silly animations from `SILLY_ANIMATIONS` (dance, pee, poop, vomit, stab, sleep, etc.)
-  - Pause between actions (1-4 seconds)
-- Speech bubbles with random flavor text (optional, nice-to-have)
-
-### 2.4 Setup Screen Integration
-
-- Add **Map Theme** picker to experiment configuration (between Arc Selector and Parameters)
-- Theme picker shows 4 themed cards with preview color swatches
-- Selected theme ID stored alongside arc/parameters
-- "Launch Experiment" navigates to `/experiment/demo` with config passed via route state or Pinia store
-
----
-
-## 3. Technical Spec
-
-### 3.1 New Files
-
-```
-src/
-├── config/
-│   └── map-themes.ts          # Theme definitions (palettes, building styles, ambient config)
-├── components/
-│   ├── setup/
-│   │   └── MapThemePicker.vue  # Theme selection card grid
-│   └── world/
-│       ├── PixiWorld.vue       # Vue wrapper for PixiJS Application
-│       └── pixi/               # Pure TypeScript PixiJS classes (no Vue imports)
-│           ├── IsometricMap.ts  # Tile grid renderer, diamond projection math
-│           ├── TileRenderer.ts  # Per-tile sprite generation from theme palette
-│           ├── BuildingRenderer.ts  # Multi-tile building shapes
-│           ├── AgentSprite.ts   # Agent pixel sprite on isometric grid
-│           └── CameraController.ts  # Pan, zoom, keyboard controls
-├── composables/
-│   └── usePixiWorld.ts         # Bridge between Vue reactivity and PixiJS
-├── types/
-│   └── world.ts                # MapTheme, TileDef, WorldConfig types
-└── views/
-    └── SimulationView.vue      # Updated: mount PixiWorld + HUD overlay
-```
-
-### 3.2 Isometric Math
-
-```
-// World (tile) → Screen (pixel) coordinates
-screenX = (tileX - tileY) * (TILE_WIDTH / 2)
-screenY = (tileX + tileY) * (TILE_HEIGHT / 2)
-
-// Screen → World (for click detection)
-tileX = (screenX / (TILE_WIDTH / 2) + screenY / (TILE_HEIGHT / 2)) / 2
-tileY = (screenY / (TILE_HEIGHT / 2) - screenX / (TILE_WIDTH / 2)) / 2
-```
-
-Tile size: 64×32 pixels (standard isometric diamond).
-
-### 3.3 Theme Palette Interface
-
-```typescript
-interface MapTheme {
-  id: string
-  name: string
-  description: string
-  tilePalette: {
-    grass: string[]      // [fill, stroke, variation]
-    path: string[]
-    building: string[]
-    fence: string[]
-    field: string[]
-    water?: string[]
-  }
-  buildingStyle: 'huts' | 'wireframe' | 'roman' | 'brutalist'
-  ambient: {
-    fogColor?: string
-    fogOpacity?: number
-    overlay?: 'rain' | 'code' | 'dust' | 'smog'
-    overlayOpacity?: number
-    tint?: string        // global color grading
-    scanlines?: boolean
-  }
-  preview: string[]      // 3-4 hex colors for the theme picker swatch
-}
-```
-
-### 3.4 Agent Sprite Integration
-
-The existing `renderCharacter()` from `character-sprites.ts` outputs a pixel grid. For PixiJS:
-1. Render character to an offscreen canvas (already done by `PixelCharacter.vue`)
-2. Convert canvas to `PIXI.Texture` via `PIXI.Texture.from(canvas)`
-3. Create `PIXI.Sprite` positioned at isometric coordinates
-4. Animate by swapping textures per pose frame
-
-### 3.5 Composable API
-
-```typescript
-// usePixiWorld.ts
-interface UsePixiWorld {
-  mount(container: HTMLElement): void
-  destroy(): void
-  loadMap(theme: MapTheme, tiles: TileDef[]): void
-  spawnAgent(id: string, sprite: CharacterSprite, tile: { x: number; y: number }): void
-  moveAgent(id: string, toTile: { x: number; y: number }): void
-  playAgentAnimation(id: string, animation: PoseName): void
-  centerOn(tileX: number, tileY: number): void
-  setZoom(level: number): void
-}
-```
-
-### 3.6 Map Data
-
-Reuse the backend's `default_town.json` tile grid structure. Each theme re-skins the same layout. The map JSON is bundled in the frontend (no backend call needed for demo).
-
----
-
-## 4. Acceptance Criteria
-
-### Must Have
-- [ ] PixiJS Application renders in SimulationView with isometric diamond tiles
-- [ ] 4 map themes selectable in experiment configuration
-- [ ] Each theme visually distinct (different ground colors, building styles, ambient effects)
-- [ ] All configured agents spawn on the map at random walkable positions
-- [ ] Agents randomly walk to adjacent tiles with smooth interpolation
-- [ ] Agents randomly play silly animations (dance, pee, poop, stab, sleep, etc.)
-- [ ] Camera pan (drag + arrow keys) and zoom (scroll wheel)
-- [ ] "Launch Experiment" button transitions from setup to simulation view
-- [ ] Map renders the full 20×20 tile grid from default_town.json
-- [ ] Building tiles render with height/depth (not flat diamonds)
-
-### Should Have
-- [ ] Location labels on hover
-- [ ] Smooth camera zoom with easing
-- [ ] Agent click selects them (highlight ring)
-- [ ] Theme-specific ambient overlay (code rain for Matrix, smog for 1984, etc.)
-
-### Nice to Have
-- [ ] Random speech bubbles with flavor text
-- [ ] Day/night cycle tint
-- [ ] Particle effects per theme (rain, dust, sparks)
-- [ ] Agent pathfinding (A* on walkable grid) instead of random neighbor
-
----
-
-## 5. Test Plan
-
-### Unit Tests
-- [ ] Isometric math: world→screen and screen→world coordinate conversion
-- [ ] TileRenderer: each theme produces distinct tile colors for each tile type
-- [ ] AgentSprite: texture generation from character sprite data
-- [ ] CameraController: pan/zoom bounds checking
-- [ ] MapTheme validation: all required palette keys present
-
-### Integration Tests
-- [ ] PixiWorld composable: mount/destroy lifecycle, no memory leaks
-- [ ] Agent spawning: N agents placed on walkable tiles only
-- [ ] Random action loop: agents cycle through animations without errors
-
-### E2E Tests
-- [ ] Setup → Launch: selecting theme and clicking launch shows isometric world
-- [ ] Agents visible on map after launch
-- [ ] Camera controls respond to mouse drag and scroll
-
----
-
-## 6. Out of Scope
-
-- Backend integration (WebSocket, real agent decisions) — that's S1.5+
-- Town meeting view — S1.7
-- Agent dossier panel — S1.6
-- Threat meter / resource HUD — S1.5
-- Custom map editor
-- Multiple map layouts (all themes use same 20×20 grid for now)
-
----
-
-## 7. Dependencies
-
-- **S1.1/S1.2** (merged) — Setup screen, pixel sprite system, character definitions
-- **PixiJS v8** — already in package.json
-- **Backend `default_town.json`** — tile grid structure (bundled as frontend asset)
+- Day/night cycle with time-of-day lighting
+- Location interaction zones (click building to see occupants)

--- a/docs/specs/arena-colosseum.md
+++ b/docs/specs/arena-colosseum.md
@@ -1,0 +1,34 @@
+---
+title: "[P3] Arena colosseum — circular design with tiered seating"
+status: todo
+issue: 44
+priority: P3
+tags: [stream-1, frontend, arena, building-renderer]
+---
+
+# Arena Colosseum — Circular Design
+
+The Gladiator/Arena theme colosseum should be circular and visually impressive.
+
+## Implementation
+
+- Modify `BuildingRenderer.ts` Arena theme rendering
+- Elliptical colosseum using PixiJS Graphics arcs
+- Tiered seating rows (3-4 levels) with stone texture
+- Arched entrance gates on cardinal directions
+- Central sand-colored arena floor
+- Stone columns between arches
+- Multi-tile footprint (3x3 or 4x4) for visual impact
+
+## Acceptance Criteria
+
+- [ ] Circular/elliptical colosseum structure
+- [ ] Visible tiered seating rows
+- [ ] Arched entrance gates
+- [ ] Central arena floor
+- [ ] Fits naturally in isometric perspective
+- [ ] Other Arena buildings unaffected
+
+## Key Files
+
+`BuildingRenderer.ts`

--- a/docs/specs/bug-arc-round-adjustment.md
+++ b/docs/specs/bug-arc-round-adjustment.md
@@ -1,0 +1,29 @@
+---
+title: "[P2] Bug: Arc timeline doesn't recalculate when round count changes"
+status: todo
+issue: 43
+priority: P2
+tags: [stream-1, frontend, bug, arc-timeline]
+---
+
+# Bug: Arc Timeline Round Adjustment
+
+When users change the number of rounds in setup/admin, the narrative arc timeline should recalculate act boundaries. Currently hardcoded to fixed round count.
+
+## Fix
+
+- `ArcTimeline.vue` reads total rounds from `experimentStore.config.totalRounds`
+- Recalculate act boundaries proportionally
+- Default: Act 1 (25%), Act 2 (50%), Act 3 (25%)
+- Watch for config changes and recompute
+
+## Acceptance Criteria
+
+- [ ] Arc recalculates when round count changes
+- [ ] Act boundaries proportional to total rounds
+- [ ] Works with default and custom arc structures
+- [ ] No hardcoded round counts
+
+## Key Files
+
+`ArcTimeline.vue`, `experimentStore`

--- a/docs/specs/e2e-game-loop.md
+++ b/docs/specs/e2e-game-loop.md
@@ -1,0 +1,44 @@
+---
+title: "[P0] E2E game loop — connect frontend to backend API/WebSocket"
+status: todo
+issue: 45
+priority: P0
+tags: [stream-1, frontend, backend, integration]
+---
+
+# E2E Game Loop
+
+Bridge frontend and backend for a fully playable simulation.
+
+## Backend API Endpoints Needed
+
+- `POST /api/experiments` — create experiment
+- `GET /api/experiments/:id` — get state
+- `POST /api/experiments/:id/start` — begin simulation
+- `POST /api/experiments/:id/pause` — pause
+- `POST /api/experiments/:id/step` — advance one round
+- `GET /api/experiments/:id/agents` — list agents
+- `GET /api/experiments/:id/events` — event log
+- WebSocket handler broadcasting phase/event messages
+
+## Frontend Wiring
+
+- Connect stores to real API endpoints
+- WebSocket handler for all 16 message types
+- Setup > create experiment > simulation > report flow
+- Game completion triggers report view
+
+## Acceptance Criteria
+
+- [ ] Create experiment from setup screen
+- [ ] Simulation runs all 6 phases per round
+- [ ] Real-time state updates via WebSocket
+- [ ] LLM-driven or mock agent decisions
+- [ ] Resources deplete, threat changes, crises occur
+- [ ] Game completes after configured rounds
+- [ ] Report shows actual data
+- [ ] Works with `MockAgentBrain` for testing
+
+## Key Files
+
+Cross-cutting (frontend stores, backend API, WebSocket)

--- a/docs/specs/highlight-reels.md
+++ b/docs/specs/highlight-reels.md
@@ -1,0 +1,60 @@
+---
+title: "[P1] Highlight reels — round recaps & post-game cinematic moments"
+status: todo
+issue: 46
+priority: P1
+tags: [stream-1, frontend, backend, highlights, narration]
+---
+
+# Highlight Reels
+
+Curated highlight reels at the end of each round and game, showcasing the most dramatic moments.
+
+## Backend: Highlight Selection
+
+- New module: `backend/app/highlights/`
+- Score events by drama: betrayals (high), crises (high), resource swings (medium), alliance changes (medium), close votes (medium), suspicion spikes (medium)
+- End-of-round: top 3-5 events
+- End-of-game: top 10-15 events
+- API: `GET /api/experiments/:id/highlights?scope=round&round=N` and `?scope=game`
+
+### Acceptance Criteria
+
+- [ ] Events scored by dramatic significance
+- [ ] Round highlights: top 3-5 per round
+- [ ] Game highlights: top 10-15 across simulation
+- [ ] API endpoint returns scored, ordered events
+- [ ] Selection accounts for variety
+
+## Frontend: Round Highlight Reel
+
+- New: `components/highlights/RoundHighlights.vue`
+- Overlay/modal at end of each round (after Night phase)
+- Auto-advance with dramatic presentation
+- Skip button, configurable disable
+
+### Acceptance Criteria
+
+- [ ] Highlight reel appears between rounds
+- [ ] Shows event description with agent context
+- [ ] Auto-advance with skip option
+- [ ] Can be disabled in config
+
+## Frontend: Game Highlight Reel
+
+- Integrate into `ReportView.vue` (S1.8)
+- Chronological/ranked display of top moments
+- Expandable entries with full context
+- Replay mode as cinematic slideshow
+- Shareable/exportable
+
+### Acceptance Criteria
+
+- [ ] Prominent section in post-game report
+- [ ] Full context per highlight
+- [ ] Replay mode
+- [ ] Exportable/shareable
+
+## Key Files
+
+`backend/app/highlights/`, `components/highlights/RoundHighlights.vue`, `views/ReportView.vue`

--- a/docs/specs/randomize-town-layouts.md
+++ b/docs/specs/randomize-town-layouts.md
@@ -1,0 +1,34 @@
+---
+title: "[P2] Randomize town layouts — procedural building placement"
+status: todo
+issue: 41
+priority: P2
+tags: [stream-1, frontend, map, randomization]
+---
+
+# Randomize Town Building Layouts
+
+Town layouts should be randomized so buildings aren't always in the same places.
+
+## Implementation
+
+- Modify `frontend/src/config/default-town.ts` for procedural building placement
+- Define placement zones (north residential, central commercial, south open)
+- Randomize building positions ensuring:
+  - No overlaps
+  - Path connectivity maintained (all buildings reachable)
+  - Perimeter fence preserved
+- Update `IsometricMap.ts` to accept dynamic tile grids
+- Seed-based randomization for reproducibility
+
+## Acceptance Criteria
+
+- [ ] Buildings in randomized positions each experiment
+- [ ] All buildings accessible via connected paths
+- [ ] Perimeter fence and water preserved
+- [ ] Same seed = same layout
+- [ ] Unit tests verify path connectivity
+
+## Key Files
+
+`default-town.ts`, `IsometricMap.ts`

--- a/docs/specs/s1.4-agent-rendering.md
+++ b/docs/specs/s1.4-agent-rendering.md
@@ -1,0 +1,75 @@
+---
+title: "[P1] Agent rendering — pathfinding, speech bubbles, status indicators, click-to-select"
+status: in_progress
+issue: 17
+priority: P1
+tags: [stream-1, frontend, pixi, agents, pathfinding]
+---
+
+# S1.4 — Agent Rendering & Interaction
+
+Enhanced agent sprite system with pathfinding, speech bubbles, status indicators, and click-to-select.
+
+## Completed (PR #33)
+
+- Agent sprite system with pixel art animations (idle, walking, talking)
+- Random walk movement between walkable tiles
+- Name labels above agent sprites
+- Selection ring visual indicator
+- Demo mode silly animations (dance, pee, poop, vomit, stab, sleep)
+
+## Remaining Work
+
+### A* Pathfinding
+- New file: `frontend/src/components/world/pixi/pathfinding.ts`
+- A* algorithm on tile grid, walkability check (grass/path = walkable; building/fence/water = blocked)
+- Integrate into `AgentSprite.ts`, replacing random adjacent tile selection
+- Path smoothing for natural movement
+
+**Acceptance Criteria:**
+- [ ] A* pathfinding finds shortest walkable path between any two tiles
+- [ ] Agents navigate around buildings, fences, and water
+- [ ] Movement looks natural with interpolated sprite position
+- [ ] Handles unreachable destinations gracefully
+- [ ] Unit tests cover edge cases
+
+### Speech Bubbles
+- New file: `frontend/src/components/world/pixi/SpeechBubble.ts`
+- PixiJS Graphics + Text above agent sprite
+- Auto-sizing bubble, fade in/out animation
+- Styles: speech (white), thought (cloud), shout (jagged)
+- Triggered by WebSocket `agent_action` events
+
+**Acceptance Criteria:**
+- [ ] Bubbles appear above agents with readable text
+- [ ] Auto-size to fit content
+- [ ] Fade in/out animation
+- [ ] Different styles for speech/thought/shout
+- [ ] Dismiss after configurable timeout (4s default)
+
+### Status Indicators
+- Extend `AgentSprite.ts` with overlay system
+- Thinking spinner (rotating dots during LLM processing)
+- Goal icon (cooperate/investigate/sabotage)
+- Suspicion glow ring (green > yellow > orange > red, 0-100)
+
+**Acceptance Criteria:**
+- [ ] Thinking spinner during decision processing
+- [ ] Goal icon displays objective type
+- [ ] Suspicion glow changes color by level
+- [ ] Updates reactively from store state
+
+### Click-to-Select
+- PixiJS `pointerdown` events on `AgentSprite.ts`
+- Emit to `usePixiWorld.ts` > updates `uiStore.selectedAgentId` + `showDossier`
+- Highlight selected agent, click empty to deselect
+
+**Acceptance Criteria:**
+- [ ] Click agent opens dossier
+- [ ] Selected agent highlighted
+- [ ] Click empty deselects
+- [ ] Selection persists across pan/zoom
+
+## Key Files
+
+`pixi/AgentSprite.ts`, `pixi/pathfinding.ts`, `pixi/SpeechBubble.ts`, `usePixiWorld.ts`

--- a/docs/specs/s1.5-hud-controls.md
+++ b/docs/specs/s1.5-hud-controls.md
@@ -1,0 +1,36 @@
+---
+title: "S1.5 — Game UI Panels"
+status: done
+issue: 18
+priority: done
+tags: [stream-1, frontend, hud, controls]
+---
+
+# S1.5 — HUD & Game Controls
+
+All HUD panels implemented in PR #33.
+
+## Completed
+
+- `ControlBar.vue` — play/pause/step/speed controls
+- `ThreatMeter.vue` — visual threat level indicator (0-100)
+- `ResourceBars.vue` — food, water, materials, power
+- `RoundCounter.vue` — current round / total rounds
+- `ArcTimeline.vue` — narrative arc progress with act boundaries
+- `GMPlanPanel.vue` — GM's current plan and crisis events
+- `NarrationOverlay.vue` — fullscreen narration text overlay
+
+## Acceptance Criteria
+
+- [x] ControlBar with play/pause/step/speed controls
+- [x] ThreatMeter displays threat level with color gradient
+- [x] ResourceBars show 4 resource types with depletion indicators
+- [x] RoundCounter tracks simulation progress
+- [x] ArcTimeline visualizes narrative structure
+- [x] GMPlanPanel shows active crisis and GM strategy
+- [x] NarrationOverlay displays dramatic text at key moments
+
+## Deferred to S1.9
+
+- Auto-approve toggle for GM actions
+- Inject observer event button

--- a/docs/specs/s1.6-agent-dossier.md
+++ b/docs/specs/s1.6-agent-dossier.md
@@ -1,0 +1,33 @@
+---
+title: "S1.6 — Agent Dossier Panel"
+status: done
+issue: 19
+priority: done
+tags: [stream-1, frontend, dossier, agents]
+---
+
+# S1.6 — Agent Dossier Panel
+
+Full slide-out dossier panel implemented in PR #33.
+
+## Completed
+
+- Slide-out panel triggered by agent selection
+- Identity section: name, archetype, personality traits, backstory
+- Goals section: current objectives with progress indicators
+- Relationships section: list of known agents with trust/suspicion scores
+- Suspicion section: current suspicion level with contributing factors
+- Live WebSocket updates: dossier data refreshes in real-time
+
+## Acceptance Criteria
+
+- [x] Slide-out dossier panel with smooth animation
+- [x] Identity section displays agent profile
+- [x] Goals section shows current objectives
+- [x] Relationships list with trust/suspicion per agent
+- [x] Suspicion level with visual indicator
+- [x] Real-time updates via WebSocket events
+
+## Deferred to S1.9
+
+- Action history timeline view

--- a/docs/specs/s1.7-social-views.md
+++ b/docs/specs/s1.7-social-views.md
@@ -1,0 +1,37 @@
+---
+title: "[P2] Relationship web — force-directed social network visualization"
+status: in_progress
+issue: 20
+priority: P2
+tags: [stream-1, frontend, social, relationships]
+---
+
+# S1.7 — Social Views
+
+## Completed (PR #33)
+
+- `ConversationBubble.vue` — agent-to-agent dialogue display
+- `TownMeeting.vue` — group meeting UI with voting mechanism
+
+## Remaining: Relationship Web Visualization
+
+- New file: `frontend/src/components/social/RelationshipWeb.vue`
+- Force-directed graph (D3.js or custom Canvas/SVG)
+- Nodes = agents (colored by archetype, sized by influence)
+- Edges = relationships (green=allied, yellow=neutral, red=hostile)
+- Edge thickness = interaction frequency
+- Data: `agentStore.agents[].relationships[]`
+- Click node > select agent > open dossier
+
+### Acceptance Criteria
+
+- [ ] Force-directed graph renders all agents as nodes
+- [ ] Edges colored by trust level (green > red)
+- [ ] Edge thickness reflects interaction frequency
+- [ ] Graph updates reactively as relationships change
+- [ ] Click node to select agent and open dossier
+- [ ] Works in both overlay and standalone panel modes
+
+## Key Files
+
+`components/social/RelationshipWeb.vue`, `stores/agent.ts`

--- a/docs/specs/s1.8-experiment-log-report.md
+++ b/docs/specs/s1.8-experiment-log-report.md
@@ -1,0 +1,47 @@
+---
+title: "[P1] Post-game report — cooperation chart, betrayal graph, goal table"
+status: in_progress
+issue: 21
+priority: P1
+tags: [stream-1, frontend, report, analytics]
+---
+
+# S1.8 — Experiment Log & Post-Game Report
+
+## Completed (PR #33)
+
+- Filterable event log with search, type filters, and phase filters
+- Real-time event streaming during simulation
+
+## Remaining: Post-Game Report Screen
+
+- New file: `frontend/src/views/ReportView.vue`
+- Route: `/report/:experimentId`
+- Auto-redirect when experiment status = "completed"
+
+### Report Sections
+
+**Cooperation Chart** — line chart of group cooperation over rounds (`experimentStore.events`)
+
+**Goal Completion Table** — all agents with goal status (achieved/failed/partial)
+
+**Betrayal Graph** — timeline of betrayals, sabotage, alliance breaks
+
+**GM Narration Timeline** — chronological crisis events and GM decisions
+
+**Highlight Reel** — top dramatic moments sorted by impact score
+
+### Acceptance Criteria
+
+- [ ] Report view loads after experiment completion
+- [ ] Cooperation chart renders line graph over rounds
+- [ ] Goal completion table shows all agents with final status
+- [ ] Betrayal graph visualizes deception timeline
+- [ ] GM narration timeline displays crisis events
+- [ ] Highlight reel surfaces top moments
+- [ ] Data sourced from `experimentStore`, `agentStore`, `gmStore`
+- [ ] Shareable/exportable report
+
+## Key Files
+
+`views/ReportView.vue`, chart components

--- a/docs/specs/s1.9-visual-polish.md
+++ b/docs/specs/s1.9-visual-polish.md
@@ -1,0 +1,66 @@
+---
+title: "[P3] Visual polish — day/night cycle, HUD enhancements, action timeline"
+status: todo
+issue: 22
+priority: P3
+tags: [stream-1, frontend, polish, visual]
+---
+
+# S1.9 — Visual Polish & Deferred Features
+
+Visual polish plus features deferred from S1.3, S1.5, and S1.6.
+
+## Day/Night Cycle (from S1.3)
+
+- Extend `AmbientOverlay.ts` with time-of-day color tinting
+- Map rounds to time periods (dawn > morning > midday > dusk > night)
+- Overlay color filters, stars/moon during night
+- Theme-specific night palettes
+
+### Acceptance Criteria
+
+- [ ] Lighting changes based on round/phase
+- [ ] Smooth transitions between time periods
+- [ ] Night phase with moon/star overlay
+- [ ] Theme-specific night palettes
+
+## HUD Enhancements (from S1.5)
+
+**Auto-Approve Toggle:**
+- Toggle in `ControlBar.vue` or `GMPlanPanel.vue`
+- GM events auto-execute when enabled
+
+**Inject Observer Event:**
+- Button to manually inject events into simulation
+- Modal with event type selector and parameters
+
+### Acceptance Criteria
+
+- [ ] Auto-approve toggle works
+- [ ] Inject event button opens creation modal
+- [ ] Custom events propagate correctly
+
+## Action History Timeline (from S1.6)
+
+- New section in dossier panel
+- Vertical timeline with round markers
+- Each entry: round, phase, action type, description, outcome
+- Data: `experimentStore.events` filtered by `agent_id`
+
+### Acceptance Criteria
+
+- [ ] Timeline displays all actions for selected agent
+- [ ] Grouped by round with phase indicators
+- [ ] Scrollable for long simulations
+
+## General Visual Polish
+
+- [ ] Consistent color scheme across HUD panels
+- [ ] Smooth panel open/close transitions
+- [ ] Loading states for async data
+- [ ] Responsive layout adjustments
+- [ ] Keyboard shortcuts (space=pause, arrows=step)
+
+## Key Files
+
+`pixi/AmbientOverlay.ts`, `pixi/IsometricMap.ts`, HUD components, dossier panel

--- a/docs/specs/s3.2-database-caching.md
+++ b/docs/specs/s3.2-database-caching.md
@@ -1,0 +1,35 @@
+---
+title: "S3.2 — Database & Caching Setup"
+status: todo
+issue: 2
+priority: null
+tags: [stream-3, infra, database, redis]
+---
+
+# S3.2 — Database & Caching Setup
+
+Set up PostgreSQL and Redis for persistence and caching.
+
+## Implementation
+
+- PostgreSQL container config + initialization scripts
+- Redis container config
+- Alembic migration runner in Docker
+- Seed data script (default town map, preset arcs)
+- Backup/restore scripts
+
+## Dependencies
+
+- S3.1 (Monorepo setup) — done
+
+## Acceptance Criteria
+
+- [ ] PostgreSQL container runs with initialization scripts
+- [ ] Redis container runs for caching layer
+- [ ] Alembic migrations execute on container startup
+- [ ] Seed data script populates default town map and preset arcs
+- [ ] Backup/restore scripts functional for local dev
+
+## Key Files
+
+`k8s/`, `docker-compose.yml`, `backend/alembic/`

--- a/docs/specs/s3.5-monitoring.md
+++ b/docs/specs/s3.5-monitoring.md
@@ -1,0 +1,46 @@
+---
+title: "S3.5 — Monitoring & Cost Tracking"
+status: todo
+issue: 5
+priority: null
+tags: [stream-3, infra, monitoring, observability]
+---
+
+# S3.5 — Monitoring & Cost Tracking
+
+Set up monitoring, logging, and LLM cost tracking.
+
+## Implementation
+
+**LLM Cost Tracking:**
+- Per-experiment, per-agent, per-round token usage + cost
+- Dashboard or API endpoint for cost visibility
+
+**Application Metrics:**
+- Active experiments count
+- Rounds processed
+- WebSocket connection count
+
+**Logging:**
+- Structured JSON logs
+- Centralized collection
+
+**Health & Readiness:**
+- Health checks for K8s liveness probes
+- Readiness probes for traffic routing
+
+## Dependencies
+
+- S3.3 (K8s manifests) — done
+
+## Acceptance Criteria
+
+- [ ] LLM token usage tracked per experiment, agent, and round
+- [ ] Cost estimates calculated from token counts
+- [ ] Application metrics exposed (active experiments, rounds, WS connections)
+- [ ] Structured JSON logging configured
+- [ ] K8s health/readiness probes functional
+
+## Key Files
+
+`k8s/`, `backend/app/`, monitoring config

--- a/docs/specs/wire-backend-data.md
+++ b/docs/specs/wire-backend-data.md
@@ -1,0 +1,40 @@
+---
+title: "[P0] Wire stores & HUD to real backend data (remove mocks)"
+status: todo
+issue: 42
+priority: P0
+tags: [stream-1, frontend, backend, data-wiring]
+---
+
+# Wire Stores & HUD to Real Backend Data
+
+Audit all components for hardcoded/mock data and wire to real backend API/WebSocket data.
+
+## Audit Areas
+
+**Stores** — 6 Pinia stores for mock initial state
+- `experimentStore` — experiment config, round state, events
+- `agentStore` — agent list, relationships, suspicion levels
+- `worldStore` — map data, tile state
+- `gmStore` — GM plans, crisis events
+- `socialStore` — conversations, meetings
+- `uiStore` — UI state (may keep defaults)
+
+**HUD Components** — ThreatMeter, ResourceBars, RoundCounter, ArcTimeline
+
+**API Service** — `api.ts` endpoint URLs and shapes
+
+**WebSocket** — `useWebSocket.ts` message handlers for all 16 types
+
+## Acceptance Criteria
+
+- [ ] Stores initialize from API data
+- [ ] HUD displays live store data
+- [ ] API endpoints match backend routes
+- [ ] WebSocket handles all message types
+- [ ] No placeholder data in production paths
+- [ ] Demo mode still works as opt-in
+
+## Key Files
+
+Stores, HUD components, `api.ts`, `useWebSocket.ts`


### PR DESCRIPTION
## Summary
- Add `CANON.yaml` config for specwright integration
- Add 15 spec files in `docs/specs/` covering every open issue
- Each spec includes frontmatter (issue #, priority, status), implementation details, and acceptance criteria
- S1.3, S1.5, S1.6 marked as done (completed in PR #33)

## Spec Files

| File | Issue | Priority |
|------|-------|----------|
| `e2e-game-loop.md` | #45 | P0 |
| `wire-backend-data.md` | #42 | P0 |
| `s1.4-agent-rendering.md` | #17 | P1 |
| `s1.8-experiment-log-report.md` | #21 | P1 |
| `highlight-reels.md` | #46 | P1 |
| `s1.7-social-views.md` | #20 | P2 |
| `randomize-town-layouts.md` | #41 | P2 |
| `bug-arc-round-adjustment.md` | #43 | P2 |
| `s1.9-visual-polish.md` | #22 | P3 |
| `arena-colosseum.md` | #44 | P3 |
| `s3.2-database-caching.md` | #2 | — |
| `s3.5-monitoring.md` | #5 | — |
| `s1.3-isometric-world.md` | #16 | done |
| `s1.5-hud-controls.md` | #18 | done |
| `s1.6-agent-dossier.md` | #19 | done |

## Test plan
- [ ] Verify all spec files render correctly on GitHub
- [ ] Confirm CANON.yaml is valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)