### PR TITLE
chore: add Canon MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "canon-mcp": {
+      "type": "stdio",
+      "command": "canon-mcp",
+      "args": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.mcp.json` to configure Canon/Specwright as an MCP server for Claude Code
- Any developer opening this project in Claude Code will automatically have access to Canon tools (spec verification, PR reviews, ticket sync)
- Requires `canonhq` to be installed locally: `uv tool install canonhq` or `pip install canonhq`

## Context
Canon/Specwright is already configured for this repo (`CANON.yaml`). This PR makes the MCP integration shareable so the whole team can use Canon commands directly in Claude Code sessions.

## Test plan
- [ ] Open a new Claude Code session in this repo
- [ ] Verify `canon-mcp` appears as an available MCP server
- [ ] Confirm Canon tools (status, verify, etc.) are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)