### PR TITLE
Add Canon plugin setup to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,51 @@ local-db-shell: ## Open psql shell to local k8s postgres
 	kubectl exec -it -n the-experiment statefulset/the-experiment-postgres -- psql -U experiment experiment
 
 # ============================================================================
+# Canon (Spec-Driven Development)
+# ============================================================================
+
+##@ Canon
+
+CANON_REPO ?= Gerner-Ventures/gv-exp-specwright
+CANON_LOCAL ?= $(abspath ../gv-exp-specwright)
+CANON_URL ?= https://specwright.gernerventures.com
+
+.PHONY: canon-setup canon-plugin canon-status
+
+canon-setup: canon-plugin ## Install Canon CLI + Claude plugin + authenticate
+	@command -v uv >/dev/null 2>&1 || { echo "Error: uv not found. Install: https://docs.astral.sh/uv/"; exit 1; }
+	@command -v canon >/dev/null 2>&1 || { echo "Installing Canon CLI from $(CANON_LOCAL)..."; uv tool install --from "$(CANON_LOCAL)" canonhq; }
+	@echo "Checking Canon auth..."
+	@CANON_URL=$(CANON_URL) canon auth status 2>/dev/null | grep -q "valid" \
+		|| { echo "Logging in to Canon..."; CANON_URL=$(CANON_URL) canon login --server $(CANON_URL) \
+		|| echo "Warning: Auth failed (server unreachable?). Canon works locally without auth. Run 'canon login --server $(CANON_URL)' later."; }
+	@echo "Canon setup complete. Restart Claude Code to load the plugin."
+
+canon-plugin: ## Install Canon Claude plugin (requires clone of specwright repo)
+	@command -v claude >/dev/null 2>&1 || { echo "Error: Claude Code CLI not found. Install Claude Code first."; exit 1; }
+	@if [ ! -d "$(CANON_LOCAL)" ]; then \
+		echo "Canon repo not found at $(CANON_LOCAL)"; \
+		echo "Clone it first:"; \
+		echo "  git clone git@github.com:$(CANON_REPO).git $(CANON_LOCAL)"; \
+		exit 1; \
+	fi
+	@# TODO: remove branch fallback after feat/canon-rebrand is merged to main
+	@if [ ! -f "$(CANON_LOCAL)/.claude-plugin/marketplace.json" ]; then \
+		echo "Checking out Canon plugin branch..."; \
+		git -C "$(CANON_LOCAL)" fetch origin 2>/dev/null; \
+		git -C "$(CANON_LOCAL)" checkout feat/canon-rebrand 2>/dev/null || git -C "$(CANON_LOCAL)" checkout main; \
+	fi
+	@echo "Registering Canon marketplace..."
+	@claude plugin marketplace add "$(CANON_LOCAL)"
+	@echo "Installing Canon plugin..."
+	@claude plugin install canon@canon --scope project
+	@echo "Done. Restart Claude Code to load the plugin."
+
+canon-status: ## Show Canon spec coverage for this project
+	@command -v canon >/dev/null 2>&1 || { echo "Error: Canon not installed. Run: make canon-setup"; exit 1; }
+	@canon status
+
+# ============================================================================
 # Cleanup
 # ============================================================================
 


### PR DESCRIPTION
## Summary
- Adds `make canon-setup`, `canon-plugin`, and `canon-status` Makefile targets
- Installs Canon CLI from local specwright repo and registers it as a Claude Code plugin marketplace
- Handles auth with fallback (server may be unreachable), points at `specwright.gernerventures.com`
- Branch-aware: checks out `feat/canon-rebrand` if marketplace manifest not yet on `main`

## Setup
```bash
# Clone specwright repo alongside this repo (one-time)
git clone git@github.com:Gerner-Ventures/gv-exp-specwright.git ../gv-exp-specwright

# Install Canon CLI + Claude plugin + authenticate
make canon-setup
```

## Depends on
- Gerner-Ventures/gv-exp-specwright `feat/canon-rebrand` (marketplace manifest + plugin.json fix)

## Test plan
- [x] `make canon-plugin` registers marketplace and installs plugin
- [x] `make canon-setup` installs CLI from local repo
- [x] Auth failure is non-fatal (server unreachable)
- [ ] Verify `/canon:*` skills available in Claude Code after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)