### PR TITLE
fix: LLM decision fallback + repair path fix

### DIFF
--- a/backend/app/agents/brain.py
+++ b/backend/app/agents/brain.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from app.agents.models import (
     ACTION_TYPES,
     AgentContext,
@@ -11,7 +13,9 @@ from app.agents.models import (
 from app.agents.registry import get_action_definition
 from app.agents.suspicion import apply_suspicion_trigger
 from app.llm import LLMService
-from app.schemas.agent_decision import AgentDecision
+from app.schemas.agent_decision import AgentDecision, DecisionAction
+
+logger = logging.getLogger(__name__)
 
 
 def build_agent_prompt(context: AgentContext) -> str:
@@ -44,21 +48,35 @@ class AgentBrain:
 
     async def decide(self, context: AgentContext) -> AgentTurnResult:
         prompt = build_agent_prompt(context)
-        result = await self.llm_service.generate_agent_decision(
-            messages=[
-                {"role": "system", "content": "Return a structured agent decision."},
-                {"role": "user", "content": prompt},
-            ],
-            response_format=AgentDecision,
-            metadata={
-                "experiment_id": context.experiment_id,
-                "agent_id": context.agent_id,
-                "round_number": context.world_state.round_number,
-            },
-            model_override=None,
-        )
-        parsed = result.parsed or {}
-        decision = AgentDecision.model_validate(parsed)
+        try:
+            result = await self.llm_service.generate_agent_decision(
+                messages=[
+                    {"role": "system", "content": "Return a structured agent decision."},
+                    {"role": "user", "content": prompt},
+                ],
+                response_format=AgentDecision,
+                metadata={
+                    "experiment_id": context.experiment_id,
+                    "agent_id": context.agent_id,
+                    "round_number": context.world_state.round_number,
+                },
+                model_override=None,
+            )
+            parsed = result.parsed or {}
+            decision = AgentDecision.model_validate(parsed)
+        except Exception:
+            logger.warning(
+                "LLM decision failed for agent %s (%s), using fallback observe action",
+                context.name, context.agent_id,
+            )
+            decision = AgentDecision(
+                inner_thought="I need a moment to read the room.",
+                suspicion=None,
+                action=DecisionAction(type="observe", location=context.location),
+                dialogue=None,
+                goal_progress="No clear progress this turn.",
+                cooperation_intent="medium",
+            )
         action = get_action_definition(decision.action.type)
 
         updated_memory = context.memory

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -180,7 +180,9 @@ class LLMClient:
                     {
                         "schema": request.response_format
                         if isinstance(request.response_format, dict)
-                        else "pydantic_model",
+                        else request.response_format.model_json_schema()
+                        if isinstance(request.response_format, type) and issubclass(request.response_format, BaseModel)
+                        else "unknown",
                         "failed_response": repair_prompt.original_text,
                         "error": repair_prompt.error,
                     }


### PR DESCRIPTION
## Summary
- `AgentBrain.decide()` catches LLM failures and returns a safe "observe" fallback instead of crashing the round
- `_repair_json` now passes actual model JSON schema instead of placeholder `"pydantic_model"` string

## Dependencies
**None** — this is the base of the stack.

**Stack:** PR 1/4 → `feat/streaming-step` → `fix/ws-store-sync` → `feat/stepping-ux`

## Files changed
- `backend/app/agents/brain.py` — try/except around LLM call with deterministic fallback
- `backend/app/llm/client.py` — use `model_json_schema()` in repair path

## Test plan
- [ ] Run a round where an agent LLM call fails (e.g., invalid API key) — should get "observe" action instead of 500
- [ ] Verify structured output repair includes actual schema in the repair prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)