### PR TITLE
fix: address S3.5 PR review feedback

### DIFF
--- a/backend/app/api/routes/metrics.py
+++ b/backend/app/api/routes/metrics.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from sqlalchemy import func, select
 
 from app.db import engine
@@ -17,8 +17,10 @@ router = APIRouter(tags=["metrics"])
     summary="Application metrics",
     description="Returns runtime metrics: active experiments, rounds processed, WebSocket connections.",
 )
-async def metrics() -> dict[str, object]:
-    from app.api.runtime import runtime
+async def metrics(request: Request) -> dict[str, object]:
+    from app.api.runtime import ExperimentRuntime
+
+    runtime: ExperimentRuntime = request.app.state.runtime
 
     async with engine.connect() as conn:
         total_row = await conn.execute(select(func.count()).select_from(Experiment))

--- a/backend/app/api/runtime.py
+++ b/backend/app/api/runtime.py
@@ -242,6 +242,15 @@ class ExperimentRuntime:
         await self._log(
             experiment_id, event_type="experiment_started", summary="Experiment started."
         )
+        log.info("experiment_started", experiment_id=experiment_id)
+        ph.capture(
+            "experiment_started",
+            {
+                "experiment_id": experiment_id,
+                "agent_count": len(state.agents),
+                "total_rounds": state.total_rounds,
+            },
+        )
         return state
 
     async def pause(self, experiment_id: str) -> SimulationState:
@@ -420,6 +429,15 @@ class ExperimentRuntime:
                 intended_round = state.current_round + 1
                 if state.status == "setup":
                     state.status = "running"
+                    log.info("experiment_started", experiment_id=experiment_id)
+                    ph.capture(
+                        "experiment_started",
+                        {
+                            "experiment_id": experiment_id,
+                            "agent_count": len(state.agents),
+                            "total_rounds": state.total_rounds,
+                        },
+                    )
 
                 # Pre-approve GM plan if needed (before engine runs)
                 if not state.auto_approve:
@@ -439,11 +457,48 @@ class ExperimentRuntime:
                     experiment_id=experiment_id,
                     runtime=self,
                 )
+                t0 = time.monotonic()
                 round_result = await self.engine.run_round(state, hook=hook)
+                round_duration = time.monotonic() - t0
 
                 await self.store.save_state(state)
                 await self.store.record_round_result(experiment_id, round_result)
                 await self._log_round_result(experiment_id, round_result, state)
+
+                log.info(
+                    "round_completed",
+                    experiment_id=experiment_id,
+                    round_number=round_result.round_number,
+                    total_rounds=state.total_rounds,
+                    threat_level=round_result.threat_level,
+                    duration_seconds=round(round_duration, 2),
+                )
+                ph.capture(
+                    "round_completed",
+                    {
+                        "experiment_id": experiment_id,
+                        "round_number": round_result.round_number,
+                        "total_rounds": state.total_rounds,
+                        "threat_level": round_result.threat_level,
+                        "duration_seconds": round(round_duration, 2),
+                    },
+                )
+
+                if state.status in ("completed", "collapsed"):
+                    log.info(
+                        "experiment_finished",
+                        experiment_id=experiment_id,
+                        status=state.status,
+                        total_rounds=state.total_rounds,
+                    )
+                    ph.capture(
+                        "experiment_finished",
+                        {
+                            "experiment_id": experiment_id,
+                            "status": state.status,
+                            "total_rounds": state.total_rounds,
+                        },
+                    )
 
             # Broadcast round_end with full state so FE can do a final sync
             await self.connection_manager.broadcast(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from app.api.router import api_router
+from app.api.runtime import runtime
 from app.core import langfuse as lf
 from app.core import posthog as ph
 from app.core.config import get_settings
@@ -19,7 +20,8 @@ settings = get_settings()
 
 
 @asynccontextmanager
-async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    app.state.runtime = runtime
     ph.init()
     lf.init()
     ph.capture("backend_started", {"version": settings.app_version})


### PR DESCRIPTION
## Summary

Follow-up to #88 — the review fixes were committed after the squash merge landed.

- **Metrics endpoint** uses `request.app.state.runtime` instead of module-global import
- **`app.state.runtime`** set in lifespan so the pattern works
- **`start()`** and **`_step_streaming()`** now emit structlog + PostHog events for experiment_started, round_completed, and experiment_finished

Addresses [review feedback](https://github.com/Gerner-Ventures/the-experiment/pull/88#pullrequestreview-3910305784) from @pwerth.

## Test plan

- [ ] `GET /api/metrics` returns correct WS count from app-scoped runtime
- [ ] `POST /api/experiments/{id}/start` emits PostHog `experiment_started`
- [ ] Streaming rounds emit `round_completed` and `experiment_finished`

🤖 Generated with [Claude Code](https://claude.com/claude-code)