### PR TITLE
Add backend highlight reel selection API

### DIFF
--- a/backend/app/api/models.py
+++ b/backend/app/api/models.py
@@ -283,10 +283,25 @@ class GMTimelinePage(APIRequestModel):
     items: list[GMRoundTimelineItem] = Field(default_factory=list)
 
 
+HighlightScope = Literal["round", "game"]
+HighlightCategory = Literal[
+    "crisis",
+    "betrayal",
+    "resource_swing",
+    "alliance_shift",
+    "close_vote",
+    "suspicion_spike",
+]
+
+
 class HighlightItem(APIRequestModel):
-    round_number: int | None = None
+    id: str
+    round_number: int
+    phase: str | None = None
     score: float = 0.0
-    category: str
+    category: HighlightCategory
+    event_type: str
+    event_kind: str | None = None
     summary: str
     data: dict[str, Any] = Field(default_factory=dict)
 
@@ -348,4 +363,6 @@ class FactionAnalytics(APIRequestModel):
 
 
 class HighlightPage(APIRequestModel):
+    scope: HighlightScope = "game"
+    round_number: int | None = None
     items: list[HighlightItem] = Field(default_factory=list)

--- a/backend/app/api/routes/experiments.py
+++ b/backend/app/api/routes/experiments.py
@@ -15,6 +15,7 @@ from app.api.models import (
     GMTimelinePage,
     GoalAnalytics,
     HighlightPage,
+    HighlightScope,
     PromptTracePage,
     RelationshipAnalytics,
     ReplayIndex,
@@ -341,15 +342,56 @@ async def get_gm_timeline(experiment_id: str, request: Request) -> GMTimelinePag
 
 
 @router.get(
+    "/{experiment_id}/highlights",
+    response_model=HighlightPage,
+    summary="Get experiment highlights",
+    description=(
+        "Return the ranked highlight reel for one round or the full game, derived from the "
+        "persisted event log and round summaries."
+    ),
+)
+async def get_highlights(
+    experiment_id: str,
+    request: Request,
+    scope: HighlightScope = Query(default="game"),
+    round_number: int | None = Query(default=None, alias="round", ge=1),
+) -> HighlightPage:
+    runtime = _runtime_from_request(request)
+    state = await _get_state(runtime, experiment_id)
+    if scope == "round" and round_number is None:
+        raise HTTPException(status_code=422, detail="round is required when scope=round")
+    if scope == "round" and round_number is not None and round_number > state.current_round:
+        raise HTTPException(status_code=404, detail="Round highlights not found")
+    return HighlightPage(
+        scope=scope,
+        round_number=round_number if scope == "round" else None,
+        items=await runtime.get_highlights(
+            experiment_id,
+            scope=scope,
+            round_number=round_number,
+        ),
+    )
+
+
+@router.get(
     "/{experiment_id}/analytics/highlights",
     response_model=HighlightPage,
     summary="Get experiment highlights",
-    description="Return the highest-signal events derived from the persisted event log.",
+    description="Backward-compatible alias for the highlight reel endpoint.",
+    include_in_schema=False,
 )
-async def get_highlights(experiment_id: str, request: Request) -> HighlightPage:
-    runtime = _runtime_from_request(request)
-    await _get_state(runtime, experiment_id)
-    return HighlightPage(items=await runtime.get_highlights(experiment_id))
+async def get_analytics_highlights(
+    experiment_id: str,
+    request: Request,
+    scope: HighlightScope = Query(default="game"),
+    round_number: int | None = Query(default=None, alias="round", ge=1),
+) -> HighlightPage:
+    return await get_highlights(
+        experiment_id=experiment_id,
+        request=request,
+        scope=scope,
+        round_number=round_number,
+    )
 
 
 @router.get(

--- a/backend/app/api/runtime.py
+++ b/backend/app/api/runtime.py
@@ -12,6 +12,8 @@ import structlog
 from app.agents.models import AgentMemoryState
 from app.api.models import (
     AnalyticsSummary,
+    AgentGoalProgress,
+    AgentSuspicionHistory,
     BetrayalTimelineItem,
     CreateExperimentRequest,
     EventLogItem,
@@ -20,9 +22,9 @@ from app.api.models import (
     FactionMembershipChange,
     FactionTimelinePoint,
     GMRoundTimelineItem,
-    AgentGoalProgress,
     GoalOutcomeSummary,
     HighlightItem,
+    HighlightScope,
     RelationshipEdge,
     ReplayIndex,
     ReplayRound,
@@ -31,12 +33,12 @@ from app.api.models import (
     SuspicionAnalytics,
     SuspicionHistoryPoint,
     SuspicionPoint,
-    AgentSuspicionHistory,
     UsageGroup,
     UsageReport,
 )
 from app.api.store import ExperimentStore, SqlAlchemyExperimentStore
 from app.api.ws_manager import ConnectionManager
+from app.highlights import HighlightSelector
 from app.db.models import AgentStatus
 from app.db.session import AsyncSessionLocal
 from app.agents.models import AgentTurnResult
@@ -107,6 +109,7 @@ class ExperimentRuntime:
         self.engine.gm_service = self.gm_service
         self.connection_manager = connection_manager or ConnectionManager()
         self.store = store or SqlAlchemyExperimentStore(AsyncSessionLocal)
+        self.highlight_selector = HighlightSelector()
         self.lock = asyncio.Lock()
         self._steps_in_progress: dict[str, bool] = {}
         self._current_tasks: dict[str, asyncio.Task[None]] = {}
@@ -915,23 +918,15 @@ class ExperimentRuntime:
                 )
         return sorted(edges, key=lambda item: abs(item.trust), reverse=True)
 
-    async def get_highlights(self, experiment_id: str) -> list[HighlightItem]:
+    async def get_highlights(
+        self,
+        experiment_id: str,
+        *,
+        scope: HighlightScope = "game",
+        round_number: int | None = None,
+    ) -> list[HighlightItem]:
         logs = await self.store.list_logs(experiment_id)
-        highlights: list[HighlightItem] = []
-        for item in logs:
-            score = self._highlight_score(item)
-            if score <= 0:
-                continue
-            highlights.append(
-                HighlightItem(
-                    round_number=item.round_number,
-                    score=score,
-                    category=item.type,
-                    summary=item.summary,
-                    data=item.data,
-                )
-            )
-        return sorted(highlights, key=lambda item: item.score, reverse=True)[:20]
+        return self.highlight_selector.select(logs, scope=scope, round_number=round_number)
 
     async def get_replay_index(self, experiment_id: str) -> ReplayIndex:
         logs = await self.store.list_logs(experiment_id)
@@ -965,7 +960,10 @@ class ExperimentRuntime:
                     gm_narration=self._string_or(round_summary.get("gm", {}).get("narration")),
                 )
             )
-        return ReplayIndex(rounds=rounds, highlights=await self.get_highlights(experiment_id))
+        return ReplayIndex(
+            rounds=rounds,
+            highlights=await self.get_highlights(experiment_id, scope="game"),
+        )
 
     async def get_round_snapshot(
         self, experiment_id: str, round_number: int
@@ -1201,33 +1199,6 @@ class ExperimentRuntime:
             group.total_tokens += record.usage.total_tokens
             group.cost_usd = round(group.cost_usd + record.usage.cost_usd, 6)
         return sorted(grouped.values(), key=lambda item: item.total_tokens, reverse=True)
-
-    def _highlight_score(self, item: EventLogItem) -> float:
-        if item.type == "exile_enacted":
-            return 10.0
-        if item.type == "cult_activity":
-            return 8.0
-        if item.type == "faction_update":
-            return 6.0
-        if item.type == "crisis_event":
-            severity = str(item.data.get("crisis_event", {}).get("severity", "low"))
-            return {"critical": 9.0, "high": 7.0, "medium": 5.0}.get(severity, 3.0)
-        if item.type == "agent_action":
-            requested_action = self._requested_action_type(item)
-            resolved_action = self._resolved_action_type(item)
-            if (
-                requested_action in SABOTAGE_ACTION_TYPES
-                or resolved_action in SABOTAGE_ACTION_TYPES
-            ):
-                return 8.0 if resolved_action in SABOTAGE_ACTION_TYPES else 5.0
-            if requested_action in HOSTILE_ACTION_TYPES or resolved_action in HOSTILE_ACTION_TYPES:
-                return 6.5 if resolved_action in HOSTILE_ACTION_TYPES else 4.0
-        if item.type == "observer_event":
-            return 7.0
-        if item.type == "round_end":
-            threat_level = float(item.data.get("threat_level", 0.0))
-            return 5.5 if threat_level >= 65 else 0.0
-        return 0.0
 
     def _message(
         self,

--- a/backend/app/highlights/__init__.py
+++ b/backend/app/highlights/__init__.py
@@ -1,0 +1,3 @@
+from .selector import HighlightSelector
+
+__all__ = ["HighlightSelector"]

--- a/backend/app/highlights/selector.py
+++ b/backend/app/highlights/selector.py
@@ -1,0 +1,473 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.api.models import EventLogItem, HighlightCategory, HighlightItem, HighlightScope
+from app.world import build_default_world_state
+
+ROUND_HIGHLIGHT_LIMIT = 5
+GAME_HIGHLIGHT_LIMIT = 12
+SABOTAGE_ACTION_TYPES = {"sabotage"}
+HOSTILE_ACTION_TYPES = {"accuse", "attack", "threaten", "stab", "shoot", "poison"}
+CRISIS_SEVERITY_SCORES = {"critical": 9.5, "high": 8.5, "medium": 7.5, "low": 6.5}
+PHASE_ORDER = {"gm_plan": 0, "dawn": 1, "morning": 2, "midday": 3, "afternoon": 4, "night": 5}
+
+
+@dataclass(slots=True)
+class HighlightCandidate:
+    item: HighlightItem
+    variety_key: str
+    sort_key: tuple[float, int, int, int]
+
+
+class HighlightSelector:
+    def __init__(self) -> None:
+        self.initial_resources = build_default_world_state().resources.model_dump(mode="json")
+
+    def select(
+        self,
+        logs: list[EventLogItem],
+        *,
+        scope: HighlightScope,
+        round_number: int | None = None,
+    ) -> list[HighlightItem]:
+        candidates = self._build_candidates(logs)
+        if scope == "round":
+            candidates = [
+                candidate for candidate in candidates if candidate.item.round_number == round_number
+            ]
+            limit = ROUND_HIGHLIGHT_LIMIT
+        else:
+            limit = GAME_HIGHLIGHT_LIMIT
+        selected = self._select_diverse(candidates, limit=limit)
+        return [candidate.item for candidate in selected]
+
+    def _build_candidates(self, logs: list[EventLogItem]) -> list[HighlightCandidate]:
+        candidates: list[HighlightCandidate] = []
+        round_end_logs: dict[int, EventLogItem] = {}
+        for index, item in enumerate(logs):
+            candidates.extend(self._event_candidates(item, index))
+            if item.type == "round_end" and item.round_number is not None:
+                round_end_logs[item.round_number] = item
+
+        previous_resources = self.initial_resources
+        previous_factions: dict[str, dict[str, Any]] = {}
+        previous_suspicion: dict[str, dict[str, Any]] = {}
+        for round_number in sorted(round_end_logs):
+            item = round_end_logs[round_number]
+            current_resources = self._resource_data(item.data)
+            current_factions = self._faction_index(item.data)
+            current_suspicion = self._suspicion_index(item.data)
+
+            resource_candidate = self._resource_swing_candidate(
+                item,
+                previous_resources=previous_resources,
+                current_resources=current_resources,
+            )
+            if resource_candidate is not None:
+                candidates.append(resource_candidate)
+
+            faction_candidate = self._faction_shift_candidate(
+                item,
+                previous_factions=previous_factions,
+                current_factions=current_factions,
+            )
+            if faction_candidate is not None:
+                candidates.append(faction_candidate)
+
+            candidates.extend(
+                self._suspicion_spike_candidates(
+                    item,
+                    previous_suspicion=previous_suspicion,
+                    current_suspicion=current_suspicion,
+                )
+            )
+
+            previous_resources = current_resources or previous_resources
+            previous_factions = current_factions
+            previous_suspicion = current_suspicion
+        return candidates
+
+    def _event_candidates(self, item: EventLogItem, index: int) -> list[HighlightCandidate]:
+        candidates: list[HighlightCandidate] = []
+        crisis = self._crisis_candidate(item, index)
+        if crisis is not None:
+            candidates.append(crisis)
+        betrayal = self._betrayal_candidate(item, index)
+        if betrayal is not None:
+            candidates.append(betrayal)
+        close_vote = self._close_vote_candidate(item, index)
+        if close_vote is not None:
+            candidates.append(close_vote)
+        return candidates
+
+    def _crisis_candidate(self, item: EventLogItem, index: int) -> HighlightCandidate | None:
+        if item.type != "crisis_event" or item.round_number is None:
+            return None
+        crisis = self._crisis_payload(item.data)
+        severity = str(crisis.get("severity", "low")).lower()
+        score = CRISIS_SEVERITY_SCORES.get(severity, 6.0)
+        return self._candidate(
+            item=item,
+            index=index,
+            category="crisis",
+            score=score,
+            variety_key="crisis",
+            summary=str(crisis.get("description") or item.summary),
+            data={
+                "severity": severity,
+                "crisis_event": crisis,
+            },
+        )
+
+    def _betrayal_candidate(self, item: EventLogItem, index: int) -> HighlightCandidate | None:
+        if item.type != "agent_action" or item.round_number is None:
+            return None
+        requested_action = self._requested_action_type(item)
+        resolved_action = self._resolved_action_type(item)
+        if requested_action in SABOTAGE_ACTION_TYPES or resolved_action in SABOTAGE_ACTION_TYPES:
+            score = 9.2 if resolved_action in SABOTAGE_ACTION_TYPES else 8.4
+        elif requested_action in HOSTILE_ACTION_TYPES or resolved_action in HOSTILE_ACTION_TYPES:
+            score = 8.0 if resolved_action in HOSTILE_ACTION_TYPES else 7.2
+        else:
+            return None
+        return self._candidate(
+            item=item,
+            index=index,
+            category="betrayal",
+            score=score,
+            variety_key="betrayal",
+            summary=item.summary,
+            data={
+                "requested_action_type": requested_action,
+                "resolved_action_type": resolved_action,
+                "agent_id": item.agent_id,
+                "target": item.data.get("target"),
+                "suspicion_level": item.data.get("suspicion_level"),
+            },
+        )
+
+    def _close_vote_candidate(self, item: EventLogItem, index: int) -> HighlightCandidate | None:
+        if item.round_number is None:
+            return None
+        kind = self._event_kind(item)
+        if kind not in {"meeting_result", "exile_vote"}:
+            return None
+        tally = item.data.get("tally")
+        if not isinstance(tally, dict):
+            return None
+        counts = sorted((int(value) for value in tally.values()), reverse=True)
+        if len(counts) < 2:
+            return None
+        margin = counts[0] - counts[1]
+        if margin > 1:
+            return None
+        total_votes = sum(counts)
+        if total_votes < 2:
+            return None
+        score = 6.6 if margin == 0 else 6.2
+        return self._candidate(
+            item=item,
+            index=index,
+            category="close_vote",
+            score=score,
+            variety_key="close_vote",
+            summary=item.summary,
+            data={
+                "tally": tally,
+                "margin": margin,
+                "total_votes": total_votes,
+                "passed": bool(item.data.get("passed") or item.data.get("enacted")),
+            },
+        )
+
+    def _resource_swing_candidate(
+        self,
+        item: EventLogItem,
+        *,
+        previous_resources: dict[str, float],
+        current_resources: dict[str, float],
+    ) -> HighlightCandidate | None:
+        if item.round_number is None or not current_resources:
+            return None
+        deltas = {
+            resource: round(
+                current_resources.get(resource, 0.0) - previous_resources.get(resource, 0.0),
+                2,
+            )
+            for resource in current_resources
+            if round(
+                current_resources.get(resource, 0.0) - previous_resources.get(resource, 0.0),
+                2,
+            )
+            != 0
+        }
+        if not deltas:
+            return None
+        magnitude = sum(abs(delta) for delta in deltas.values())
+        if magnitude < 2.0:
+            return None
+        summary = self._resource_summary(item.round_number, deltas)
+        score = min(7.4, round(5.0 + magnitude * 0.35, 2))
+        return self._candidate(
+            item=item,
+            index=10_000 + item.round_number,
+            category="resource_swing",
+            score=score,
+            variety_key="resource_swing",
+            summary=summary,
+            data={
+                "resource_delta": deltas,
+                "resources": current_resources,
+                "previous_resources": previous_resources,
+            },
+        )
+
+    def _faction_shift_candidate(
+        self,
+        item: EventLogItem,
+        *,
+        previous_factions: dict[str, dict[str, Any]],
+        current_factions: dict[str, dict[str, Any]],
+    ) -> HighlightCandidate | None:
+        if item.round_number is None:
+            return None
+        formed = sorted(
+            faction["name"]
+            for faction_id, faction in current_factions.items()
+            if faction_id not in previous_factions
+        )
+        dissolved = sorted(
+            faction["name"]
+            for faction_id, faction in previous_factions.items()
+            if faction_id not in current_factions
+        )
+        joined: list[str] = []
+        left: list[str] = []
+        for faction_id, faction in current_factions.items():
+            previous_members = set(previous_factions.get(faction_id, {}).get("member_ids", []))
+            current_members = set(faction.get("member_ids", []))
+            joined.extend(
+                sorted(str(member_id) for member_id in current_members - previous_members)
+            )
+            left.extend(sorted(str(member_id) for member_id in previous_members - current_members))
+        change_count = len(formed) + len(dissolved) + len(joined) + len(left)
+        if change_count == 0:
+            return None
+        summary = self._faction_summary(item.round_number, formed, dissolved, joined, left)
+        score = min(7.1, round(5.2 + change_count * 0.45, 2))
+        return self._candidate(
+            item=item,
+            index=20_000 + item.round_number,
+            category="alliance_shift",
+            score=score,
+            variety_key="alliance_shift",
+            summary=summary,
+            data={
+                "formed_factions": formed,
+                "dissolved_factions": dissolved,
+                "joined_agent_ids": joined,
+                "left_agent_ids": left,
+                "factions": list(current_factions.values()),
+            },
+        )
+
+    def _suspicion_spike_candidates(
+        self,
+        item: EventLogItem,
+        *,
+        previous_suspicion: dict[str, dict[str, Any]],
+        current_suspicion: dict[str, dict[str, Any]],
+    ) -> list[HighlightCandidate]:
+        candidates: list[HighlightCandidate] = []
+        if item.round_number is None:
+            return candidates
+        for agent_id, current in current_suspicion.items():
+            previous = previous_suspicion.get(agent_id)
+            if previous is None:
+                continue
+            delta = round(float(current["suspicion_level"]) - float(previous["suspicion_level"]), 2)
+            if delta < 8.0:
+                continue
+            score = min(7.0, round(5.1 + delta * 0.12, 2))
+            candidates.append(
+                self._candidate(
+                    item=item,
+                    index=30_000 + item.round_number,
+                    category="suspicion_spike",
+                    score=score,
+                    variety_key="suspicion_spike",
+                    summary=(
+                        f"{current['agent_name']} draws a surge of suspicion in round "
+                        f"{item.round_number} (+{delta:.1f})."
+                    ),
+                    data={
+                        "agent_id": agent_id,
+                        "agent_name": current["agent_name"],
+                        "suspicion_level": current["suspicion_level"],
+                        "previous_suspicion_level": previous["suspicion_level"],
+                        "delta": delta,
+                    },
+                )
+            )
+        return candidates
+
+    def _select_diverse(
+        self, candidates: list[HighlightCandidate], *, limit: int
+    ) -> list[HighlightCandidate]:
+        ordered = sorted(candidates, key=lambda candidate: candidate.sort_key)
+        if len(ordered) <= limit:
+            return ordered
+
+        selected: list[HighlightCandidate] = []
+        seen_variety: set[str] = set()
+        for candidate in ordered:
+            if candidate.variety_key in seen_variety:
+                continue
+            selected.append(candidate)
+            seen_variety.add(candidate.variety_key)
+            if len(selected) == limit:
+                return selected
+
+        if len(selected) < limit:
+            selected_ids = {candidate.item.id for candidate in selected}
+            for candidate in ordered:
+                if candidate.item.id in selected_ids:
+                    continue
+                selected.append(candidate)
+                selected_ids.add(candidate.item.id)
+                if len(selected) == limit:
+                    break
+        return selected
+
+    def _candidate(
+        self,
+        *,
+        item: EventLogItem,
+        index: int,
+        category: HighlightCategory,
+        score: float,
+        variety_key: str,
+        summary: str,
+        data: dict[str, Any],
+    ) -> HighlightCandidate:
+        event_kind = self._event_kind(item)
+        highlight = HighlightItem(
+            id=f"{item.id}:{category}",
+            round_number=item.round_number or 0,
+            phase=item.phase,
+            score=round(score, 2),
+            category=category,
+            event_type=item.type,
+            event_kind=event_kind,
+            summary=summary,
+            data=data,
+        )
+        return HighlightCandidate(
+            item=highlight,
+            variety_key=variety_key,
+            sort_key=(
+                -highlight.score,
+                highlight.round_number,
+                self._phase_sort_key(highlight.phase),
+                index,
+            ),
+        )
+
+    def _event_kind(self, item: EventLogItem) -> str | None:
+        kind = item.data.get("kind")
+        return kind if isinstance(kind, str) else None
+
+    def _crisis_payload(self, data: dict[str, Any]) -> dict[str, Any]:
+        crisis = data.get("crisis_event")
+        return crisis if isinstance(crisis, dict) else {}
+
+    def _requested_action_type(self, item: EventLogItem) -> str | None:
+        requested_action = item.data.get("requested_action_type")
+        return requested_action if isinstance(requested_action, str) else None
+
+    def _resolved_action_type(self, item: EventLogItem) -> str | None:
+        resolved_action = item.data.get("resolved_action_type")
+        if isinstance(resolved_action, str):
+            return resolved_action
+        action_type = item.data.get("action_type")
+        return action_type if isinstance(action_type, str) else None
+
+    def _resource_data(self, data: dict[str, Any]) -> dict[str, float]:
+        resources = data.get("resources")
+        if not isinstance(resources, dict):
+            return {}
+        return {
+            resource: float(value)
+            for resource, value in resources.items()
+            if isinstance(resource, str) and isinstance(value, (int, float))
+        }
+
+    def _faction_index(self, data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+        factions = data.get("factions")
+        if not isinstance(factions, list):
+            return {}
+        indexed: dict[str, dict[str, Any]] = {}
+        for faction in factions:
+            if not isinstance(faction, dict):
+                continue
+            faction_id = faction.get("faction_id")
+            if not isinstance(faction_id, str):
+                continue
+            indexed[faction_id] = {
+                "faction_id": faction_id,
+                "name": str(faction.get("name") or faction_id),
+                "member_ids": [str(member_id) for member_id in faction.get("member_ids", [])],
+            }
+        return indexed
+
+    def _suspicion_index(self, data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+        suspicion = data.get("suspicion")
+        if not isinstance(suspicion, list):
+            return {}
+        indexed: dict[str, dict[str, Any]] = {}
+        for entry in suspicion:
+            if not isinstance(entry, dict):
+                continue
+            agent_id = entry.get("agent_id")
+            agent_name = entry.get("agent_name")
+            suspicion_level = entry.get("suspicion_level")
+            if not isinstance(agent_id, str) or not isinstance(agent_name, str):
+                continue
+            if not isinstance(suspicion_level, (int, float)):
+                continue
+            indexed[agent_id] = {
+                "agent_name": agent_name,
+                "suspicion_level": float(suspicion_level),
+            }
+        return indexed
+
+    def _resource_summary(self, round_number: int, deltas: dict[str, float]) -> str:
+        major_changes = sorted(deltas.items(), key=lambda item: abs(item[1]), reverse=True)[:2]
+        changes = ", ".join(
+            f"{resource} {'+' if delta > 0 else ''}{delta:g}" for resource, delta in major_changes
+        )
+        return f"Round {round_number} jolts the resource balance: {changes}."
+
+    def _faction_summary(
+        self,
+        round_number: int,
+        formed: list[str],
+        dissolved: list[str],
+        joined: list[str],
+        left: list[str],
+    ) -> str:
+        if formed:
+            return f"Round {round_number} forges {', '.join(formed[:2])} into the political map."
+        if dissolved:
+            return f"Round {round_number} fractures {', '.join(dissolved[:2])}."
+        if joined or left:
+            return (
+                f"Round {round_number} scrambles faction loyalties with "
+                f"{len(joined)} joins and {len(left)} departures."
+            )
+        return f"Round {round_number} reshapes the alliance map."
+
+    def _phase_sort_key(self, phase: str | None) -> int:
+        return PHASE_ORDER.get(phase or "", 99)

--- a/backend/tests/test_api_docs.py
+++ b/backend/tests/test_api_docs.py
@@ -33,6 +33,10 @@ def test_docs_and_openapi_endpoints_are_available() -> None:
         == "Get round analytics"
     )
     assert (
+        body["paths"]["/api/experiments/{experiment_id}/highlights"]["get"]["summary"]
+        == "Get experiment highlights"
+    )
+    assert (
         body["paths"]["/api/experiments/{experiment_id}/usage"]["get"]["summary"]
         == "Get LLM usage report"
     )

--- a/backend/tests/test_api_layer.py
+++ b/backend/tests/test_api_layer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from collections.abc import Generator
 import time
 from types import SimpleNamespace
@@ -10,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from app.agents.models import AgentTurnResult
 from app.agents.service import AgentService
+from app.api.models import EventLogItem
 from app.api.runtime import ExperimentRuntime
 from app.api.store import InMemoryExperimentStore
 from app.core.config import Settings
@@ -276,11 +278,6 @@ def test_analytics_and_replay_endpoints_return_round_data(client: TestClient) ->
     assert snapshot.json()["round_number"] == 1
     assert snapshot.json()["events"]
 
-    highlights = client.get(f"{API_PREFIX}/experiments/{experiment_id}/analytics/highlights")
-    assert highlights.status_code == 200
-    assert highlights.json()["items"]
-    assert highlights.json()["items"][0]["category"] == "crisis_event"
-
 
 def test_derived_round_logs_are_persisted(client: TestClient) -> None:
     created = client.post(f"{API_PREFIX}/experiments", json=_payload())
@@ -309,6 +306,63 @@ def test_derived_round_logs_are_persisted(client: TestClient) -> None:
     )
     assert round_end.status_code == 200
     assert round_end.json()["total"] == 1
+
+
+def test_highlights_endpoint_supports_round_and_game_scope(
+    client: TestClient, runtime: ExperimentRuntime
+) -> None:
+    created = client.post(f"{API_PREFIX}/experiments", json=_payload())
+    experiment_id = created.json()["experiment_id"]
+    _seed_highlight_logs(runtime, experiment_id)
+
+    game_highlights = client.get(f"{API_PREFIX}/experiments/{experiment_id}/highlights")
+    assert game_highlights.status_code == 200
+    assert game_highlights.json()["scope"] == "game"
+    assert len(game_highlights.json()["items"]) <= 12
+    game_categories = {item["category"] for item in game_highlights.json()["items"]}
+    assert {
+        "crisis",
+        "betrayal",
+        "resource_swing",
+        "alliance_shift",
+        "close_vote",
+    } <= game_categories
+
+    round_highlights = client.get(
+        f"{API_PREFIX}/experiments/{experiment_id}/highlights",
+        params={"scope": "round", "round": 2},
+    )
+    assert round_highlights.status_code == 200
+    assert round_highlights.json()["scope"] == "round"
+    assert len(round_highlights.json()["items"]) <= 5
+    assert all(item["round_number"] == 2 for item in round_highlights.json()["items"])
+    round_categories = {item["category"] for item in round_highlights.json()["items"]}
+    assert {
+        "betrayal",
+        "resource_swing",
+        "alliance_shift",
+        "close_vote",
+        "suspicion_spike",
+    } <= round_categories
+
+    legacy_alias = client.get(
+        f"{API_PREFIX}/experiments/{experiment_id}/analytics/highlights",
+        params={"scope": "round", "round": 2},
+    )
+    assert legacy_alias.status_code == 200
+    assert legacy_alias.json() == round_highlights.json()
+
+
+def test_round_highlights_require_round_query(client: TestClient) -> None:
+    created = client.post(f"{API_PREFIX}/experiments", json=_payload())
+    experiment_id = created.json()["experiment_id"]
+
+    response = client.get(
+        f"{API_PREFIX}/experiments/{experiment_id}/highlights",
+        params={"scope": "round"},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"] == "round is required when scope=round"
 
 
 def test_report_grade_analytics_use_resolved_action_outcomes(
@@ -574,3 +628,123 @@ def _wait_for_round_completion(
     raise AssertionError(
         f"Timed out waiting for experiment {experiment_id} to reach round {expected_round}."
     )
+
+
+def _seed_highlight_logs(runtime: ExperimentRuntime, experiment_id: str) -> None:
+    state = runtime.store.states[experiment_id]
+    state.current_round = 2
+    runtime.store.states[experiment_id] = state
+    timestamps = [
+        datetime(2026, 3, 7, 12, 0, tzinfo=UTC) + timedelta(minutes=index) for index in range(6)
+    ]
+    items = [
+        EventLogItem(
+            id="highlight-crisis-r1",
+            experiment_id=experiment_id,
+            round_number=1,
+            phase="dawn",
+            type="crisis_event",
+            summary="A public accusation turns the first dawn into open panic.",
+            data={
+                "crisis_event": {
+                    "type": "social",
+                    "description": "A public accusation turns the first dawn into open panic.",
+                    "affects": ["trust"],
+                    "severity": "high",
+                }
+            },
+            timestamp=timestamps[0],
+        ),
+        EventLogItem(
+            id="highlight-betrayal-r1",
+            experiment_id=experiment_id,
+            round_number=1,
+            phase="afternoon",
+            agent_id="mara",
+            type="agent_action",
+            summary="Mara sabotages the generator while the town searches for answers.",
+            data={
+                "requested_action_type": "sabotage",
+                "resolved_action_type": "sabotage",
+            },
+            timestamp=timestamps[1],
+        ),
+        EventLogItem(
+            id="highlight-round-end-r1",
+            experiment_id=experiment_id,
+            round_number=1,
+            phase="round_end",
+            type="round_end",
+            summary="Round 1 closes with brittle calm.",
+            data={
+                "summary": "Round 1 closes with brittle calm.",
+                "resources": {"food": 10.0, "water": 10.0, "materials": 8.0, "power": 7.0},
+                "factions": [],
+                "suspicion": [
+                    {"agent_id": "mara", "agent_name": "Mara", "suspicion_level": 22.0},
+                    {"agent_id": "jon", "agent_name": "Jon", "suspicion_level": 14.0},
+                ],
+            },
+            timestamp=timestamps[2],
+        ),
+        EventLogItem(
+            id="highlight-betrayal-r2",
+            experiment_id=experiment_id,
+            round_number=2,
+            phase="afternoon",
+            agent_id="mara",
+            type="agent_action",
+            summary="Mara openly threatens Jon to keep control of the town square.",
+            data={
+                "requested_action_type": "threaten",
+                "resolved_action_type": "threaten",
+            },
+            timestamp=timestamps[3],
+        ),
+        EventLogItem(
+            id="highlight-vote-r2",
+            experiment_id=experiment_id,
+            round_number=2,
+            phase="midday",
+            type="midday",
+            summary="The town barely backs Jon's search plan with two votes to one.",
+            data={
+                "kind": "meeting_result",
+                "proposal": "Search the perimeter for the missing supplies",
+                "tally": {"support": 2, "oppose": 1, "abstain": 0},
+                "passed": True,
+            },
+            timestamp=timestamps[4],
+        ),
+        EventLogItem(
+            id="highlight-round-end-r2",
+            experiment_id=experiment_id,
+            round_number=2,
+            phase="round_end",
+            type="round_end",
+            summary="Round 2 ends with the town split into camps.",
+            data={
+                "summary": "Round 2 ends with the town split into camps.",
+                "resources": {"food": 5.0, "water": 10.0, "materials": 8.0, "power": 7.0},
+                "factions": [
+                    {
+                        "faction_id": "alliance:jon",
+                        "name": "Jon's Watch",
+                        "kind": "alliance",
+                        "leader_id": "jon",
+                        "member_ids": ["jon", "mara"],
+                        "influence": 61.0,
+                        "formed_round": 2,
+                        "pressure": 58.0,
+                    }
+                ],
+                "suspicion": [
+                    {"agent_id": "mara", "agent_name": "Mara", "suspicion_level": 40.0},
+                    {"agent_id": "jon", "agent_name": "Jon", "suspicion_level": 15.0},
+                ],
+            },
+            timestamp=timestamps[5],
+        ),
+    ]
+    for item in items:
+        runtime.store.logs[experiment_id].append(item)

--- a/docs/API.md
+++ b/docs/API.md
@@ -67,7 +67,7 @@ Important behavior:
 | `GET` | `/api/experiments/{experiment_id}/analytics/relationships` | Relationship graph edges derived from agent memory |
 | `GET` | `/api/experiments/{experiment_id}/analytics/factions` | Current faction state plus pressure and membership-change timeline |
 | `GET` | `/api/experiments/{experiment_id}/analytics/gm` | GM narration and crisis timeline by round |
-| `GET` | `/api/experiments/{experiment_id}/analytics/highlights` | High-signal events ranked from the log |
+| `GET` | `/api/experiments/{experiment_id}/highlights` | Variety-aware highlight reel for a round or the full game |
 | `GET` | `/api/experiments/{experiment_id}/replay` | Replay index with round summaries and highlights |
 | `GET` | `/api/experiments/{experiment_id}/rounds/{round_number}/snapshot` | World snapshot and per-round events |
 | `GET` | `/api/experiments/{experiment_id}/usage` | Aggregated LLM usage by role, model, agent, and round |
@@ -180,7 +180,14 @@ Useful follow-up reads after a round completes:
 
 - `GET /api/experiments/{id}/log?round_number=N`
 - `GET /api/experiments/{id}/rounds/{N}/snapshot`
-- `GET /api/experiments/{id}/analytics/highlights`
+- `GET /api/experiments/{id}/highlights?scope=round&round=N`
+  - returns the end-of-round reel for one completed round
+  - up to 5 highlights, scored and ordered by dramatic significance
+  - categories currently include `betrayal`, `crisis`, `resource_swing`, `alliance_shift`, `close_vote`, and `suspicion_spike`
+- `GET /api/experiments/{id}/highlights?scope=game`
+  - returns the cross-game reel
+  - up to 12 highlights, ranked from the persisted log and round summaries
+  - selection prefers category variety before filling the remaining slots by score
 - `GET /api/experiments/{id}/usage?round_number=N`
 
 ## Event Log Filters
@@ -254,11 +261,14 @@ Additional report-grade analytics endpoints expose persisted derived views for f
   - round theme
   - narration
   - crisis payload
+- `GET /api/experiments/{experiment_id}/highlights`
+  - `scope=round` requires `round`
+  - items include the ranked category, source `event_type`, optional `event_kind`, round, phase, score, summary, and contextual data
 
 `GET /api/experiments/{experiment_id}/replay` returns a replay-friendly index:
 
 - one item per completed round with a summary, threat level, event count, cooperation score, sabotage count, betrayal count, and GM context
-- the same highlight feed used by the analytics highlight endpoint
+- the same game-scoped highlight feed used by the highlights endpoint
 
 `GET /api/experiments/{experiment_id}/usage` and `.../usage/traces` expose LLM usage:
 

--- a/docs/GAME_RUNTIME.md
+++ b/docs/GAME_RUNTIME.md
@@ -427,6 +427,7 @@ The API runtime now persists report-grade derived analytics at round end:
 - `agent_action` log rows include both requested and resolved action types
 - `round_end` log rows include compact round summaries for cooperation, goals, suspicion, factions, and GM context
 - replay and analytics endpoints read from those persisted summaries instead of reconstructing everything from websocket-only state
+- the highlight reel endpoint combines both sources: event-log rows drive crisis, betrayal, and close-vote moments, while `round_end` summaries drive resource swings, alliance shifts, and suspicion spikes
 
 ## Runtime Ownership
 


### PR DESCRIPTION
## Summary
- add a dedicated backend highlight selector that scores crises, betrayals, resource swings, alliance shifts, close votes, and suspicion spikes
- expose the issue 46 highlights contract at `GET /api/experiments/{id}/highlights` with `scope=round&round=N` or `scope=game`
- update replay/tests/docs and keep the old analytics route as a hidden compatibility alias

## Testing
- poetry run pytest -q

Refs #46