### PR TITLE
Fix frontend cleanup after agent_move websocket removal

### DIFF
--- a/docs/AGENT_RUNTIME.md
+++ b/docs/AGENT_RUNTIME.md
@@ -408,7 +408,6 @@ Use round and social events to animate or narrate runtime changes.
 Relevant event families:
 
 - `agent_action`
-- `agent_move`
 - `agent_speak`
 - `meeting_speech`
 - `meeting_vote`
@@ -416,6 +415,9 @@ Relevant event families:
 - `cult_activity`
 - `exile_vote`
 - `exile_enacted`
+
+`agent_action` carries the mid-round action payload, including `action.location` when the frontend
+should update an agent's current location before `round_end`.
 
 ## Replay and analytics
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,7 +88,6 @@ const messageRouter: Record<string, (data: any) => void> = {
   'gm_plan':          (d) => gmStore.onPlan(d),
   'gm_narration':     (d) => gmStore.onNarration(d),
   'agent_action':     (d) => agentStore.onAction(d),
-  'agent_move':       (d) => agentStore.onMove(d),
   'agent_speak':      (d) => socialStore.onSpeak(d),
   'crisis_event':     (d) => worldStore.onCrisis(d),
   'threat_update':    (d) => worldStore.onThreatUpdate(d),
@@ -101,6 +100,9 @@ const messageRouter: Record<string, (data: any) => void> = {
   'experiment_end':   (d) => experimentStore.onEnd(d),
 }
 ```
+
+`agent_action` is the only mid-round agent activity message. Location changes now come through
+`agent_action.data.action.location`; the final authoritative state still arrives in `round_end`.
 
 **Rules:**
 - One WebSocket connection per experiment session.

--- a/docs/specs/consolidate-broadcast-paths.md
+++ b/docs/specs/consolidate-broadcast-paths.md
@@ -16,8 +16,8 @@ There are two code paths that broadcast WebSocket messages during a round:
 2. **`_StreamingHook`** — New path used by `start_step()` / `_step_streaming()`. Broadcasts events live as each phase completes via the `RoundHook` callback interface.
 
 Both paths use the shared `_EVENT_KIND_TO_WS_TYPE` mapping, but they produce different WS message sequences for the same logical round:
-- `broadcast_round` emits `agent_move`, `resource_update`, and `threat_update` as separate messages
-- `_StreamingHook` does not emit these (relies on per-action `agent_action` broadcasts and the final `round_end` payload)
+- `broadcast_round` emits `resource_update` and `threat_update` as separate messages
+- `_StreamingHook` relies on per-action `agent_action` broadcasts for mid-round movement via `action.location`, then finishes with the final `round_end` payload
 
 This duplication will drift as new event types or broadcast behaviors are added.
 

--- a/docs/specs/streaming-step-tests.md
+++ b/docs/specs/streaming-step-tests.md
@@ -36,7 +36,7 @@ Test the 4 hook methods broadcast the correct WS message types:
 - `on_round_start` → broadcasts `round_start`
 - `on_phase_start` → broadcasts `phase_change` with `status: "starting"`
 - `on_phase_complete` → broadcasts `phase_change` with events + individual typed messages
-- `on_agent_action` → broadcasts `agent_action` and optionally `agent_move`
+- `on_agent_action` → broadcasts `agent_action`, including any movement in `action.location`
 
 ### 4. `AgentBrain.decide()` LLM fallback
 

--- a/frontend/tests/unit/stores.spec.ts
+++ b/frontend/tests/unit/stores.spec.ts
@@ -252,7 +252,16 @@ describe('agentStore', () => {
       expect(store.agentCount).toBe(2)
     })
 
-    it('updates agent location from structured move actions', () => {
+    it('updates agent location from structured action payloads', () => {
+      const store = useAgentStore()
+      store.setAgents(sampleAgents)
+      store.onAction(makeMsg({ type: 'agent_action', data: { agent_id: 'a1', action: { type: 'gather', location: 'beach' }, summary: '' } }))
+      const agent = store.getAgent('a1')!
+      expect(agent.location).toBe('beach')
+      expect(agent.status).toBe('working')
+    })
+
+    it('updates move actions from structured action payloads', () => {
       const store = useAgentStore()
       store.setAgents(sampleAgents)
       store.onAction(makeMsg({ type: 'agent_action', data: { agent_id: 'a1', action: { type: 'move', location: 'beach' }, summary: '' } }))


### PR DESCRIPTION
## Summary
- remove stale websocket docs that still describe `agent_move` as a live frontend/runtime message
- document that mid-round location updates now come from `agent_action.data.action.location`
- add frontend store coverage for structured `agent_action` payloads that carry location data

## Testing
- npm test -- --runInBand tests/unit/ws-routing.spec.ts tests/unit/stores.spec.ts

Closes #127