### PR TITLE
Tune PR review skill readability and tone

### DIFF
--- a/.codex/skills/pr-review/SKILL.md
+++ b/.codex/skills/pr-review/SKILL.md
@@ -119,6 +119,7 @@ Classification labels do not need to be fancy, but they should be concrete. Emoj
 - Use Markdown that renders cleanly on GitHub: short headers, bold labels, compact bullets, and short paragraphs with breathing room.
 - Lean into emoji for scanning, especially on `REQUEST_CHANGES` reviews. A little troll energy is fine, including the occasional `💩` when the code path truly earned it.
 - Dry sarcasm, mild mockery, and "this code is being weird" energy are all welcome.
+- On `APPROVE` reviews, positive sarcasm and silly praise are welcome too. Lines like `Awesome job!!!` or `I'm proud of you, great work!!` are fair game when the PR actually earned it.
 - Keep the humor pointed at the bad code path, not the human who wrote it.
 - Prefer lines that sound like a sharp reviewer with taste, not a generic assistant trying to be quirky.
 - If the PR introduces a truly catastrophic bug, you may be blunt and a bit mean, but still keep the review actionable and specific.
@@ -143,7 +144,8 @@ Before submitting:
 
 - Make sure the body is easy to scan on GitHub with a top line like `Verdict: Request changes 🚫🧱💀💩`, then sections such as `## Blocking`, `## Non-blocking`, and `## Checks`.
 - Put the verdict on one line. Do not render a `## Verdict` header with the decision stranded beneath it.
-- For `REQUEST_CHANGES`, feel free to be louder with negative emoji, including `💩` when it helps sell the disaster. For approvals, keep it lighter.
+- For `REQUEST_CHANGES`, feel free to be louder with negative emoji, including `💩` when it helps sell the disaster.
+- For approvals, keep the emoji lighter, but feel free to sound theatrically pleased when the work is genuinely strong.
 - Mention tests/checks run when relevant.
 - Set a local `verdict` variable first (`APPROVE` or `REQUEST_CHANGES`) so the submission path is unambiguous.
 - If the submit command errors after the network request may already have reached GitHub, do not blindly retry. First inspect the PR's latest review from your account, confirm whether the review was created, and only resubmit if it definitely was not.


### PR DESCRIPTION
## Summary
- break review findings into short paragraphs with more visual breathing room
- switch the verdict to a single-line format and make request-changes reviews more overtly trollish
- add finding classifications with emoji-friendly labels and sassier tone guidance

## Testing
- not run (docs-only skill change)
