### PR TITLE
fix: default auto_approve to true until GM plan approval UI is built

### DIFF
--- a/backend/app/api/models.py
+++ b/backend/app/api/models.py
@@ -36,7 +36,7 @@ class AgentCreateRequest(APIRequestModel):
 class CreateExperimentRequest(APIRequestModel):
     name: str
     total_rounds: int = Field(default=15, ge=1)
-    auto_approve: bool = True
+    auto_approve: bool = False
     preset_arc_id: str = "lord_of_the_flies"
     arc: DirectorArc | None = None
     agents: list[AgentCreateRequest] = Field(default_factory=list)


### PR DESCRIPTION
Without this, every step request returns 409 because the backend requires a GM plan to be generated and approved first — but there is no UI for that flow yet.